### PR TITLE
Add readable debug logs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -123,4 +123,4 @@ issues:
         - promlinter
     - linters:
         - errcheck
-      source: log\..+\.Log\(\"
+      source: log\..+\.Log\(

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -60,10 +60,13 @@ func (gdb *GormDB) setup(obj interface{}) {
 	}
 }
 
-type TestDB struct{}
+type TestDB struct {
+	TestFunc func(...Samples)
+}
 
 func (tdb *TestDB) SetupDefaults() {
 }
 
 func (tdb *TestDB) AddSamples(samples ...Samples) {
+	tdb.TestFunc(samples...)
 }

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-type Event struct {
+type Message struct {
 	Type string `json:"type"`
 	Data Data   `json:"data"`
 }


### PR DESCRIPTION
Also only outputs the full data when `--db.type=test`, and outputs JSON data.